### PR TITLE
Update mods.toml

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -32,7 +32,7 @@ issueTrackerURL="https://github.com/MinecraftModDevelopmentMods/Extra-Golems/iss
 [[dependencies.golems]]
     modId="thermal"
     mandatory=false
-    versionRange="[1.16.3-1.0.5,)"
+    versionRange="[1.0.5,)"
     ordering="AFTER"
     side="BOTH"
 [[dependencies.golems]]


### PR DESCRIPTION
Changed the Thermal dependency to match the `Implementation-Version` string found in Thermal manifest, as with a change in Forge from https://github.com/MinecraftForge/MinecraftForge/issues/7696 this causes a crash because the version number minimum of `1.16.3-1.0.5` doesn't match.

Mekanism and Immersive Engineering are fine, but what a mess it is for these declarations, some do it in manifest.mf, others in mods.toml...some prepend minecraft version others do not, a standard would be nice FFS.