### PR TITLE
Fix MinecraftModDevelopmentMods/Extra-Golems#113

### DIFF
--- a/src/main/java/com/mcmoddev/golems/ExtraGolems.java
+++ b/src/main/java/com/mcmoddev/golems/ExtraGolems.java
@@ -59,11 +59,17 @@ public class ExtraGolems {
 	private static final String PROTOCOL_VERSION = "2";
 	public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(new ResourceLocation(MODID, "channel"), () -> PROTOCOL_VERSION, PROTOCOL_VERSION::equals, PROTOCOL_VERSION::equals);
 
-	private static final CodecJsonDataManager<GolemContainer> GOLEM_CONTAINER_JSON_MANAGER = new CodecJsonDataManager<>("golem_stats", GolemContainer.CODEC);
 	public static final Map<ResourceLocation, GolemContainer> GOLEM_CONTAINER_MAP = new HashMap<>();
+	private static final CodecJsonDataManager<GolemContainer> GOLEM_CONTAINER_JSON_MANAGER = new CodecJsonDataManager<>("golem_stats", GolemContainer.CODEC, map -> {
+		GOLEM_CONTAINER_MAP.clear();
+		GOLEM_CONTAINER_MAP.putAll(map);
+	});
 
-	private static final CodecJsonDataManager<GolemRenderSettings> GOLEM_MODEL_JSON_MANAGER = new CodecJsonDataManager<>("golem_models", GolemRenderSettings.CODEC);
 	public static final Map<ResourceLocation, GolemRenderSettings> GOLEM_MODEL_MAP = new HashMap<>();
+	private static final CodecJsonDataManager<GolemRenderSettings> GOLEM_MODEL_JSON_MANAGER = new CodecJsonDataManager<>("golem_models", GolemRenderSettings.CODEC, map -> {
+		GOLEM_MODEL_MAP.clear();
+		GOLEM_MODEL_MAP.putAll(map);
+	});
 
 	public ExtraGolems() {
 		// register and load config

--- a/src/main/java/com/mcmoddev/golems/util/CodecJsonDataManager.java
+++ b/src/main/java/com/mcmoddev/golems/util/CodecJsonDataManager.java
@@ -69,6 +69,8 @@ public class CodecJsonDataManager<T> extends SimpleJsonResourceReloadListener
 
     /** The raw data that we parsed from json last time resources were reloaded **/
     protected Map<ResourceLocation, T> data = new HashMap<>();
+    
+    private Consumer<Map<ResourceLocation, T>> applyConsumer;
 
     /**
      * Creates a data manager with a standard gson parser
@@ -77,9 +79,9 @@ public class CodecJsonDataManager<T> extends SimpleJsonResourceReloadListener
      * folderName can include subfolders, e.g. "some_mod_that_adds_lots_of_data_loaders/cheeses"
      * @param codec A codec to deserialize the json into your T, see javadocs above class
      */
-    public CodecJsonDataManager(String folderName, Codec<T> codec)
+    public CodecJsonDataManager(String folderName, Codec<T> codec, Consumer<Map<ResourceLocation, T>> applyConsumer)
     {
-        this(folderName, codec, STANDARD_GSON);
+        this(folderName, codec, applyConsumer, STANDARD_GSON);
     }
 
     /**
@@ -91,11 +93,12 @@ public class CodecJsonDataManager<T> extends SimpleJsonResourceReloadListener
      * @param gson A gson for parsing the raw json data into JsonElements. JsonElement-to-T conversion will be done by the codec,
      * so gson type adapters shouldn't be necessary here
      */
-    public CodecJsonDataManager(String folderName, Codec<T> codec, Gson gson)
+    public CodecJsonDataManager(String folderName, Codec<T> codec, Consumer<Map<ResourceLocation, T>> applyConsumer, Gson gson)
     {
         super(gson, folderName);
         this.folderName = folderName; // superclass has this but it's a private field
         this.codec = codec;
+        this.applyConsumer = applyConsumer;
     }
 
     /**
@@ -125,6 +128,11 @@ public class CodecJsonDataManager<T> extends SimpleJsonResourceReloadListener
         }
 
         this.data = newMap;
+        
+        if(this.applyConsumer != null) {
+        	this.applyConsumer.accept(this.data);
+        }
+        
         LOGGER.info("Data loader for {} loaded {} jsons", this.folderName, this.data.size());
     }
 


### PR DESCRIPTION
The cause for this issue is due the maps GOLEM_CONTAINER_MAP and GOLEM_MODEL_MAP being empty when player loads a world and not being populated before the first load of a Golem MOB, so, causing a fail on the method setMaterial that fallsback to a "empty" golem.

The fastest way I've found to fix the issue is including a callback on the class CodecJsonDataManager that, after loading the models from jsons, populate the respective map (cited above).

Of course, is possible to simplify the implementation with a simple call to putAll on the constant Map directly, inside the class CodecJsonDataManager, removing the Consumer<> parameter.